### PR TITLE
Pass options to react-templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function(file, options) {
 
   function transformer(source) {
     // Stripping types needs to happen before the other transforms
-    return reactTemplates.convertTemplateToReact(source);
+    return reactTemplates.convertTemplateToReact(source, options);
   }
 
   return process(file, isRTFile, transformer);


### PR DESCRIPTION
`react-template` supports building CommonJS modules in addition to AMD, and this PR passes options from the browserify transform. Users of `react-templatify` can use this to compile HTML templates to CommonJS modules, removing the need for `deamdify`.

To pass the `modules` option in `package.json`:

``` javascript
"browserify": {
    "transform": [
      ["react-templatify", {"modules": "commonjs"}]
    ]
  }
```

To pass the `modules` option on the command line:

`browserify file.rt -t [ react-templatify --modules=commonjs ]`

(The default for this setting is 'amd' so `react-template` uses that if it receives no options)
